### PR TITLE
docs: document design and AI usage

### DIFF
--- a/AI_USO.md
+++ b/AI_USO.md
@@ -1,0 +1,3 @@
+# Uso de IA
+
+Se utilizó una herramienta de inteligencia artificial (ChatGPT) para asistir en la generación de documentación y comentarios en el código de este proyecto.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Recepción de Textos Escolares
+
+## Decisiones de diseño
+
+- **Vue 3 + Composition API**: permite una sintaxis clara y componible para manejar estado y lógica reutilizable.
+- **Almacenamiento en `localStorage`**: se optó por persistir los datos localmente para conservar la información entre sesiones sin requerir un backend.
+- **Componentización**: la aplicación se divide en componentes (`Recepciones`, `Libros`, `Proveedores`) para mejorar la mantenibilidad y escalabilidad.
+- **Vite como bundler**: ofrece un entorno de desarrollo rápido y una configuración mínima.
+- **Validaciones reactivas**: se usan `computed` y `watch` para validar formularios y mantener coherencia en los datos.
+
+## Cómo ejecutar
+
+```bash
+npm install
+npm run dev
+```
+
+## Construcción del proyecto
+
+```bash
+npm run build
+```

--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@ import Proveedores from './components/Proveedores.vue'
 import Libros from './components/Libros.vue'
 import Recepciones from './components/Recepciones.vue'
 
+// Se usa un ref para recordar la pestaña activa sin recurrir a un sistema de ruteo completo
 const tab = ref('recepciones')
 </script>
 
@@ -13,13 +14,13 @@ const tab = ref('recepciones')
     <h1>Recepción de Textos Escolares</h1>
 
     <div class="hstack">
-      <!-- Se marca la pestaña activa correctamente -->
+      <!-- Botones que actúan como pestañas, simplificando la navegación -->
       <button :class="{active:tab==='recepciones'}" @click="tab='recepciones'">Recepciones</button>
       <button :class="{active:tab==='libros'}" @click="tab='libros'">Libros</button>
       <button :class="{active:tab==='proveedores'}" @click="tab='proveedores'">Proveedores</button>
     </div>
 
-    <!-- Renderizado condicional de cada sección -->
+    <!-- Renderizado condicional para evitar cargar componentes innecesarios -->
     <Recepciones v-if="tab==='recepciones'" />
     <Libros v-if="tab==='libros'" />
     <Proveedores v-if="tab==='proveedores'" />
@@ -27,6 +28,7 @@ const tab = ref('recepciones')
 </template>
 
 <style scoped>
+/* Estilos locales para evitar efectos en otros componentes */
 .container{max-width:1024px;margin:24px auto;padding:16px;font-family:system-ui}
 .hstack{display:flex;gap:8px;margin:12px 0}
 button.active{outline:2px solid #2563eb}

--- a/src/stores/useRecepcionStore.js
+++ b/src/stores/useRecepcionStore.js
@@ -1,9 +1,11 @@
 // Store central con persistencia en localStorage
 import { reactive, watch } from 'vue'
 
+// Clave única para aislar los datos del resto de la plataforma
 const KEY = 'recepcion-store'
 
 // Estructura inicial de datos
+// Definir valores de ejemplo facilita las pruebas y sirve como documentación viva
 const defaults = {
   proveedores: [
     { id: 1, nombre: 'Editorial Santillana', rut: '76.123.456-7', contacto: 'soporte@santillana.cl' }
@@ -21,14 +23,17 @@ const defaults = {
 }
 
 // Cargamos desde localStorage o usamos los valores por defecto
+// `reactive` se usa para evitar dependencias adicionales como Pinia manteniendo reactividad
 const state = reactive(JSON.parse(localStorage.getItem(KEY) || 'null') || defaults)
 
 // Guarda el estado ante cualquier cambio profundo
+// `deep: true` garantiza que incluso cambios anidados se sincronicen
 watch(state, val => {
   localStorage.setItem(KEY, JSON.stringify(val))
 }, { deep: true })
 
 // Hook de acceso al estado
+// Exponerlo como función permite reusar la misma instancia en toda la app
 export function useRecepcionStore(){
   return { state }
 }


### PR DESCRIPTION
## Summary
- add README with key design decisions
- document AI assistance in AI_USO.md
- justify tab logic and store persistence via inline comments

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b86e3ea1d4833285b83916aa934d47